### PR TITLE
Fix strategy fifo as default if not defined.

### DIFF
--- a/src/mysql_poolboy.erl
+++ b/src/mysql_poolboy.erl
@@ -30,7 +30,12 @@
 
 %% @doc Adds a pool to the started mysql_poolboy application.
 add_pool(PoolName, PoolArgs, MysqlArgs) ->
-    PoolSpec = child_spec(PoolName, PoolArgs, MysqlArgs),
+    %% We want strategy fifo as default instead of lifo.
+    PoolArgs1 = case proplists:is_defined(strategy, PoolArgs) of
+        true  -> PoolArgs;
+        false -> PoolArgs ++ [{strategy, fifo}]
+    end,
+    PoolSpec = child_spec(PoolName, PoolArgs1, MysqlArgs),
     supervisor:start_child(mysql_poolboy_sup, PoolSpec).
 
 %% @doc Returns a mysql connection to the given pool.


### PR DESCRIPTION
Added fifo as default instead of lifo if it's not declared in pool args.
This is so each connection will be used so we minimize connection timeout from mysql.